### PR TITLE
Fixed cross_entropy usage

### DIFF
--- a/notebooks/intro_to_continual_learning.ipynb
+++ b/notebooks/intro_to_continual_learning.ipynb
@@ -497,7 +497,7 @@
         "        x = F.relu(self.fc1(x))\n",
         "        x = F.dropout(x, training=self.training)\n",
         "        x = self.fc2(x)\n",
-        "        return F.log_softmax(x, dim=1)"
+        "        return x"
       ],
       "execution_count": 0,
       "outputs": []
@@ -548,7 +548,7 @@
         "        x, y = x.to(device), y.to(device)\n",
         "        output = model(x)\n",
         "        test_loss += F.cross_entropy(output, y).item() # sum up batch loss\n",
-        "        pred = output.max(1, keepdim=True)[1] # get the index of the max log-probability\n",
+        "        pred = output.max(1, keepdim=True)[1] # get the index of the max logit\n",
         "        correct += pred.eq(y.view_as(pred)).sum().item()\n",
         "\n",
         "    test_loss /= len(t_train)\n",


### PR DESCRIPTION
This modify doesn't affect the results, but it should be more correct to just use cross_entropy loss without adding log_softmax, because cross_entropy already adds it https://pytorch.org/docs/0.4.0/nn.html#cross-entropy