### PR TITLE
Error correction in def test

### DIFF
--- a/notebooks/intro_to_continual_learning.ipynb
+++ b/notebooks/intro_to_continual_learning.ipynb
@@ -526,7 +526,7 @@
     "        pred = output.max(1, keepdim=True)[1] # get the index of the max logit\n",
     "        correct += pred.eq(y.view_as(pred)).sum().item()\n",
     "\n",
-    "    test_loss /= len(t_train)\n",
+    "    test_loss /= len(t_test)\n",
     "    print('Test set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\\n'.format(\n",
     "        test_loss, correct, len(t_test),\n",
     "        100. * correct / len(t_test)))\n",


### PR DESCRIPTION
@vlomonaco In `def test`, it looks like `test_loss /=len(t_train)` should be replaced with `test_loss /=len(t_test)`.