### PR TITLE
Mnist error

### DIFF
--- a/scripts/mnist.py
+++ b/scripts/mnist.py
@@ -11,6 +11,12 @@ filename = [
 ["test_labels","t10k-labels-idx1-ubyte.gz"]
 ]
 
+# quick fix for https://github.com/pytorch/vision/issues/1938
+# yann.lecun.com server has moved under CloudFlare protection
+opener = request.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+request.install_opener(opener)
+
 def download_mnist():
     base_url = "http://yann.lecun.com/exdb/mnist/"
     for name in filename:

--- a/scripts/mnist.py
+++ b/scripts/mnist.py
@@ -13,6 +13,11 @@ filename = [
 
 # quick fix for https://github.com/pytorch/vision/issues/1938
 # yann.lecun.com server has moved under CloudFlare protection
+def download_file(url, filename):
+    opener = request.URLopener()
+    opener.addheader('User-Agent', 'Mozilla/5.0')
+    opener.retrieve(url, filename)
+
 opener = request.build_opener()
 opener.addheaders = [('User-agent', 'Mozilla/5.0')]
 request.install_opener(opener)
@@ -21,7 +26,7 @@ def download_mnist():
     base_url = "http://yann.lecun.com/exdb/mnist/"
     for name in filename:
         print("Downloading "+name[1]+"...")
-        request.urlretrieve(base_url+name[1], name[1])
+        download_file(base_url+name[1], name[1])
     print("Download complete.")
 
 def save_mnist():

--- a/scripts/mnist.py
+++ b/scripts/mnist.py
@@ -18,10 +18,6 @@ def download_file(url, filename):
     opener.addheader('User-Agent', 'Mozilla/5.0')
     opener.retrieve(url, filename)
 
-opener = request.build_opener()
-opener.addheaders = [('User-agent', 'Mozilla/5.0')]
-request.install_opener(opener)
-
 def download_mnist():
     base_url = "http://yann.lecun.com/exdb/mnist/"
     for name in filename:


### PR DESCRIPTION
Added a quick fix for MNIST download falling with HTTP Error 403. According to https://github.com/pytorch/vision/issues/1938, this is due to yann.lecun.com server moving under CloudFlare protection.